### PR TITLE
Fix visual glitch with one-use booster

### DIFF
--- a/Code/OneUseBoost(er).cs
+++ b/Code/OneUseBoost(er).cs
@@ -26,6 +26,7 @@ namespace Celeste.Mod.Anonhelper {
         private static IEnumerator BoosterDeath(On.Celeste.Booster.orig_BoostRoutine orig, Booster self, Player player, Vector2 direction) {
             if (self is OneUseBooster) {
                 self.Scene.Remove(DynamicData.For(self).Get<Entity>("outline"));
+                DynamicData.For(self).Get<VertexLight>("light").Visible = false;
             }
 
             yield return new SwapImmediately(orig(self, player, direction));


### PR DESCRIPTION
Currently the vertex light hangs around for a second after the bubble disappears. This change removes it at the same time as the outline